### PR TITLE
Enable Material 3 theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,8 +16,15 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
+      themeMode: ThemeMode.system,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorSchemeSeed: Colors.deepPurple,
+        useMaterial3: true,
+      ),
+      darkTheme: ThemeData(
+        colorSchemeSeed: Colors.deepPurple,
+        brightness: Brightness.dark,
+        useMaterial3: true,
       ),
       home: const LandingPage(),
     );


### PR DESCRIPTION
## Summary
- update theming to use Material 3 with a dark theme

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869264be2cc8320a641759aa580df46